### PR TITLE
Corrects macos example error

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ chmod +x snykctl
 And for macOS:
 
 ```console
-wget -o snykctl https://github.com/garethr/snykctl/releases/download/v0.2.0/snykctl_v0.2.0_darwin-amd64
+curl -L -o snykctl https://github.com/garethr/snykctl/releases/download/v0.2.0/snykctl_v0.2.0_darwin-amd64
 chmod +x snykctl
 ```
 


### PR DESCRIPTION
macOS doesn't ship with wget by default but does have curl.

curl -L is equivalent to wget so this command update should work for any mac user